### PR TITLE
update the projection matrix only if the fov changes or the aspexct ratio changes

### DIFF
--- a/src/Camera.rs
+++ b/src/Camera.rs
@@ -1,6 +1,9 @@
 
 
 use crate::World::FPosition;
+use crate::Renderer::*;
+use crate::GPUData::*;
+
 use nalgebra::{Vector3, Point3, Matrix4};
 
 pub struct Camera {
@@ -11,6 +14,12 @@ pub struct Camera {
 
     pub position: FPosition,
     pub target: FPosition,
+
+    pub projection_matrix: Matrix4<f32>,
+    pub view_matrix: Matrix4<f32>,
+
+    // this is the view * proj matrix, so the gpu doesnt have to do it for each vertex
+    pub projection_view_matrix: [[f32; 4]; 4],
 
 }
 
@@ -29,6 +38,26 @@ impl Camera {
         let position: FPosition = FPosition::new(0.0, 2.0, -5.0);
         let target: FPosition = FPosition::new(0.0, 0.0, 0.0);
 
+        // calc these as matricies so they can be multiplied together
+        let projection_matrix: Matrix4<f32> = nalgebra::Perspective3::new(
+            aspectRatio, 
+            fov, 
+            nearPlane, 
+            farPlane).to_homogeneous();
+
+        let view_matrix: Matrix4<f32> = nalgebra::Perspective3::new(
+            aspectRatio, 
+            fov, 
+            nearPlane, 
+            farPlane
+        ).to_homogeneous();
+
+        
+        // using nalgebra to multiply the view and projection matrix together
+        let projection_view_matrix: [[f32; 4]; 4] = (projection_matrix * view_matrix).into();
+
+
+    
         Camera {
             fov,
             aspectRatio,
@@ -37,28 +66,58 @@ impl Camera {
 
             position,
             target,
+
+            projection_matrix,
+            view_matrix,
+
+            projection_view_matrix,
         }
     }
 
     
     // Calculate the view matrix
-    pub fn calculate_view_matrix(&self) -> Matrix4<f32> {
-        nalgebra::Isometry3::look_at_rh(
+    pub fn calculate_view_matrix(&mut self) {
+        self.view_matrix = nalgebra::Isometry3::look_at_rh(
             &Point3::new(self.position.x, self.position.y, self.position.z), 
             &Point3::new(self.target.x, self.target.y, self.target.z), 
             &Vector3::y()
-        ).to_homogeneous()
+        ).to_homogeneous().into();
+
+        // update the proj view matrix 
+        self.projection_view_matrix = (self.projection_matrix * self.view_matrix).into();
     }
 
     //TODO: #76 update the projection matrix only if the fov changes or the aspexct ratio changes
     // calculate the projection matrix, this shouldnt change unless fov changes, or aspect ratio changes
-    pub fn calculate_projection_matrix(&self) -> Matrix4<f32> {
-        nalgebra::Perspective3::new(
+    pub fn calculate_projection_matrix(&mut self) {
+        self.projection_matrix = nalgebra::Perspective3::new(
             self.aspectRatio, 
             self.fov, 
             self.nearPlane, 
             self.farPlane
-        ).to_homogeneous()
+        ).to_homogeneous().into();
+
+        // update the proj view matrix
+        self.projection_view_matrix = (self.projection_matrix * self.view_matrix).into();
+    }
+
+
+    // this is called once per frame and will update the cameras projection and view matricies and send them to the staging buffer
+    pub fn update(&mut self, renderer: &mut Renderer, gpuData: &GPUData) {
+
+        // update the view matrix and the combined
+        self.calculate_view_matrix();
+
+        // update the uniform buffer with the new camera position matricies
+        renderer.vertUniforms.projection_view_matrix = self.projection_view_matrix;
+
+        // update the gpus staging buffer
+        // update the staging gpu buffers and set the flag that this data has changed
+        renderer.queue.write_buffer(&gpuData.vertex_uniform_staging_buf, 0, bytemuck::bytes_of(&renderer.vertUniforms));
+
+        // submit those write buffers so they are run
+        renderer.queue.submit(std::iter::empty());
+
     }
 
 }

--- a/src/Renderer.rs
+++ b/src/Renderer.rs
@@ -32,6 +32,7 @@ pub struct Renderer {
     pub render_pipeline: RenderPipeline,
     pub surfaceConfig: SurfaceConfiguration,
     pub bind_group: wgpu::BindGroup,
+    pub vertUniforms: VertexUniforms, 
     pub uniform_buffer: wgpu::Buffer,
     pub depth_texture: wgpu::Texture,
 }
@@ -120,10 +121,9 @@ impl Renderer {
 
         
         // TODO: #79 move this uniform buffer into the gpu data, also create a staging buffer for it like instances
-        // this holsd the uniform data for the vertex shader, the view and projection matrixies
+        // this holsd the uniform data for the vertex shader, the view and projection matrixies combined
         let vertUniforms: VertexUniforms = VertexUniforms {
-            view: camera.calculate_view_matrix().into(),
-            projection: camera.calculate_projection_matrix().into(),
+            projection_view_matrix: camera.projection_view_matrix,
         };
 
         // Create a buffer on the GPU and copy your uniform data into it
@@ -238,6 +238,7 @@ impl Renderer {
             render_pipeline,
             surfaceConfig,
             bind_group,
+            vertUniforms,
             uniform_buffer,
             depth_texture,
         }
@@ -249,6 +250,5 @@ impl Renderer {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct VertexUniforms {
-    pub view: [[f32; 4]; 4],
-    pub projection: [[f32; 4]; 4],
+    pub projection_view_matrix: [[f32; 4]; 4],
 }

--- a/src/Shaders/myVert.wgsl
+++ b/src/Shaders/myVert.wgsl
@@ -6,8 +6,7 @@ struct VertexOutput {
 };
 
 struct VertexUniforms {
-    view: mat4x4<f32>,
-    projection: mat4x4<f32>,
+    projection_view_matrix: mat4x4<f32>,
 };
 
 // Break down the model matrix into four vec4<f32> types
@@ -35,7 +34,7 @@ fn main(@location(0) position: vec3<f32>, instance: Instance, @location(6) colou
     );
 
     // Multiply the position by the model matrix from the instance data
-    output.pos = uniformBuffer.projection * uniformBuffer.view * model * vec4<f32>(position, 1.0);
+    output.pos = uniformBuffer.projection_view_matrix * model * vec4<f32>(position, 1.0);
 
 
     output.fragColor = colour;


### PR DESCRIPTION
Fixes #76

cameras view matrix is calculated once per frame
projection matrix once at the start and then only if the screen changes

then a combined projection_view matrix is calculated on the cpu so it doesnt need to be dont on the gpu every vertex

this is sent to the gpu every frame, first to a staging buffer at the vert start of a frame, and then to the gpu just before the frame render pass