### PR TITLE
James01010101/issue118

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # RustCraft
-Minecraft from scratch using Rust
-
-// with window stuff
+Minecraft from scratch using Rust and wgpu
 testing shaders
 https://github.com/austinEng/webgpu-samples/blob/main/src/shaders/basic.vert.wgsl
 
@@ -15,14 +13,6 @@ Z: forward and back, forward is positive, backwards is negative
 
 the point of a block is the front bottom left vertex
 same for the start of a chunk
-
-
-**GL Functions** 
-BufferData copys the data to the gpu, it allocates a new array for the data and will automatically free the unused one
-give it either DYNAMIC_DRAW or STATIC_DRAW, dynamic is for objects ill change the values on constantly
-static for objects that dont have values changed often, but they can still change
-
-BufferSubData rewrites data in a buffer, doesnt realloc.
 
 
 **Static and Dynamic Objects** 
@@ -52,7 +42,6 @@ away feom the camera up to say 10 blocks away
 then i just check theough the blocks and check the first one i hit that is not air
 
 can also use queus for lighting 
-
 
 
 **GitHub** 

--- a/benches/bench_fill_chunk_hashmap.rs
+++ b/benches/bench_fill_chunk_hashmap.rs
@@ -29,7 +29,7 @@ where
     // set some as touching air
     for x in 0..chunk_sizes.0 {
         for z in 0..chunk_sizes.2 {
-            temp_chunk_vector_global[x][(chunk_sizes.1 / 2) - 1][z].touching_air = true;
+            temp_chunk_vector_global[x][(chunk_sizes.1 / 2) - 1][z].is_touching_air = true;
         }
     }
 

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ cleanworldrun: cleanworld run
 
 # test crates
 test: clear
-	cargo test
+	cargo test -- --nocapture
 
 # run my benchmarks, in nightly because bench cant be used in stable
 bench: clear

--- a/src/Chunk/mod.rs
+++ b/src/Chunk/mod.rs
@@ -1,5 +1,5 @@
 pub mod chunk_functions;
-pub mod chunk_gpu_function;
+pub mod chunk_gpu_functions;
 pub mod create_chunks;
 
 use crate::{block::*, renderer::*, types::*};

--- a/src/Shaders/check_air_compute.wgsl
+++ b/src/Shaders/check_air_compute.wgsl
@@ -26,7 +26,7 @@ fn get_index(x: u32, y: u32, z: u32) -> u32 {
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
 
-    let id: u32 = global_id.x;
+    let id: u32 = global_id.x + global_id.y * dimentions_buffer[0] + global_id.z * dimentions_buffer[0] * dimentions_buffer[1];
     var newid: u32 = 0;
 
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -13,7 +13,7 @@ pub struct Block {
     pub model_matrix: [[f32; 4]; 4],
 
     // so i know to send it to the gpu or not (later only send faces touching air)
-    pub touching_air: bool,
+    pub is_touching_air: bool,
 }
 
 impl Block {
@@ -41,7 +41,7 @@ impl Block {
                 z: pos_z,
             },
             model_matrix,
-            touching_air: false,
+            is_touching_air: false,
         }
     }
 }

--- a/src/main_game_loop.rs
+++ b/src/main_game_loop.rs
@@ -45,8 +45,8 @@ pub fn run_main_game_loop() {
     let mut world: World = World::new(
         "James's World".to_string(), 
         1, 
-        5, 
-        (8, 16, 8)
+        3, 
+        (32, 256, 32)
     );
 
     // create the gpudata buffers

--- a/src/optimisations/opt_fill_chunk_hashmap.rs
+++ b/src/optimisations/opt_fill_chunk_hashmap.rs
@@ -31,7 +31,7 @@ pub fn fill_chunk_hashmap_old(
                     );
 
                     // also if it is touching air then add it to the instances to render hashmap
-                    if temp_chunk_vec[x][y][z].touching_air {
+                    if temp_chunk_vec[x][y][z].is_touching_air {
                         instances_to_render.insert(
                             (
                                 temp_chunk_vec[x][y][z].position.x,
@@ -71,7 +71,7 @@ pub fn fill_chunk_hashmap_new_1(
                 if temp_chunk_vec[x][y][z].block_type != BlockType::Air {
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if temp_chunk_vec[x][y][z].touching_air {
+                    if temp_chunk_vec[x][y][z].is_touching_air {
                         instances_to_render.insert(
                             (
                                 temp_chunk_vec[x][y][z].position.x,
@@ -144,7 +144,7 @@ pub fn fill_chunk_hashmap_new_2(
                     cached_key = (cached_position.x, cached_position.y, cached_position.z);
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if cached_block.touching_air {
+                    if cached_block.is_touching_air {
                         instances_to_render.insert(
                             cached_key,
                             InstanceData {
@@ -208,7 +208,7 @@ pub fn fill_chunk_hashmap_new_3(
                     cached_key = (cached_position.x, cached_position.y, cached_position.z);
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if cached_block.touching_air {
+                    if cached_block.is_touching_air {
                         instances_to_insert.push(InstanceData {
                             model_matrix: cached_block.model_matrix.clone(),
                             colour: cached_block.block_type.block_colour(),
@@ -272,7 +272,7 @@ pub fn fill_chunk_hashmap_new_4(
                     cached_key = (cached_position.x, cached_position.y, cached_position.z);
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if cached_block.touching_air {
+                    if cached_block.is_touching_air {
                         instances_to_insert.push((cached_key,
                             InstanceData {
                                 model_matrix: cached_block.model_matrix.clone(),
@@ -328,7 +328,7 @@ pub fn fill_chunk_hashmap_new_5(
                     cached_key = (cached_position.x, cached_position.y, cached_position.z);
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if block.touching_air {
+                    if block.is_touching_air {
                         instances_to_insert.push((cached_key,
                             InstanceData {
                                 model_matrix: block.model_matrix.clone(),
@@ -378,7 +378,7 @@ pub fn fill_chunk_hashmap_new_6(
                     blocks_to_insert.push((cached_key, *block));
 
                     // and if it is touching air then add it to the instances to render hashmap
-                    if block.touching_air {
+                    if block.is_touching_air {
                         instances_to_insert.push((cached_key,
                             InstanceData {
                                 model_matrix: block.model_matrix.clone(),

--- a/tests/test_check_air.rs
+++ b/tests/test_check_air.rs
@@ -1,0 +1,184 @@
+
+
+extern crate rust_craft;
+use rust_craft::{
+    block::*, 
+    block_type::*,
+    chunk::{chunk_functions::*, chunk_gpu_functions::*, create_chunks::*}, 
+};
+
+use async_std::task;
+use wgpu::{Device, Queue, ShaderModule};
+
+
+
+pub async fn get_renderer_variables() -> (Device, Queue, ShaderModule) {
+    
+    let instance = wgpu::Instance::default();
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        })
+        .await
+        .unwrap();
+
+    let (device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                label: None,
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::default(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let shader_code =
+        device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("check air compute shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("../src/Shaders/check_air_compute.wgsl").into(),
+            ),
+        });
+
+    (device, queue, shader_code)
+}
+
+// these all assume chunk sizes of (32 x 256 x 32)
+fn test_check_air(chunk_sizes: (usize, usize, usize)) {
+
+    // create the parts of the renderer that i need
+    let (device, queue, shader_code) = task::block_on(get_renderer_variables());
+
+    // get the chunk data
+    let mut temp_chunk_vector: Vec<Vec<Vec<Block>>> = create_temp_chunk_vector((0, 0), chunk_sizes);
+    generate_chunk(&mut temp_chunk_vector, chunk_sizes);
+    
+
+    // run the check air function
+    task::block_on(check_for_touching_air(
+        &mut temp_chunk_vector, 
+        &device, 
+        &queue, 
+        &shader_code, 
+        chunk_sizes
+    ));
+
+
+    // tests the results
+    for y in 0..chunk_sizes.1 {
+        for x in 0..chunk_sizes.0 {
+            for z in 0..chunk_sizes.2 {
+                if temp_chunk_vector[x][y][z].block_type != BlockType::Air {
+                    // check the blocks around this one that are touching it (do some bounds checking to not go out of bounds)
+                    // and if any blocks are air then it should be touching air
+                    // up
+                    let mut touching_air_count: u32 = 0;
+                    if y < chunk_sizes.1 - 1 {
+                        if temp_chunk_vector[x][y + 1][z].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // down
+                    if y > 0 {
+                        if temp_chunk_vector[x][y - 1][z].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // left
+                    if x > 0 {
+                        if temp_chunk_vector[x - 1][y][z].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // right
+                    if x < chunk_sizes.0 - 1 {
+                        if temp_chunk_vector[x + 1][y][z].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // front
+                    if z > 0 {
+                        if temp_chunk_vector[x][y][z - 1].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // back
+                    if z < chunk_sizes.2 - 1 {
+                        if temp_chunk_vector[x][y][z + 1].block_type == BlockType::Air {
+                            assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true);
+                            touching_air_count += 1;
+                        }
+                    }
+
+                    // finally check if any touched air then it should be true otherwise false
+                    if touching_air_count == 0 {
+                        assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, false,
+                        "After checking all sides this block didnt touch any air blocks but is_touching_air is true");
+                    } else {
+                        assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, true,
+                        "After checking all sides this block touched air blocks but is_touching_air is false");
+                    }
+                    
+                } else {
+                    // if it is an air block it should be not touching air
+                    assert_eq!(temp_chunk_vector[x][y][z].is_touching_air, false,
+                    "This block is an air block but is_touching_air, is true");
+                }
+            }
+        }
+    }
+}
+
+
+// testing a smaller size
+#[test]
+fn test_check_air_1() {
+    test_check_air((8, 16, 8));
+}
+
+
+// testing the size i would be using for the game
+#[test]
+fn test_check_air_2() {
+    test_check_air((32, 256, 32));
+}
+
+// testing larger sizes for fun
+#[test]
+fn test_check_air_3() {
+    test_check_air((64, 256, 64));
+}
+
+// these work but are large and take a while to run so i will ignore them
+#[test]
+#[ignore]
+fn test_check_air_4() {
+    test_check_air((64, 512, 64));
+}
+
+#[test]
+#[ignore]
+fn test_check_air_5() {
+    test_check_air((128, 512, 128));
+}
+
+#[test]
+#[ignore]
+fn test_check_air_6() {
+    test_check_air((256, 512, 256));
+}
+

--- a/tests/test_fill_chunk_hashmap.rs
+++ b/tests/test_fill_chunk_hashmap.rs
@@ -27,7 +27,7 @@ where
     // set some as touching air
     for x in 0..chunk_sizes.0 {
         for z in 0..chunk_sizes.2 {
-            temp_chunk_vector_global[x][(chunk_sizes.1 / 2) - 1][z].touching_air = true;
+            temp_chunk_vector_global[x][(chunk_sizes.1 / 2) - 1][z].is_touching_air = true;
         }
     }
 


### PR DESCRIPTION
modified the check air function and compute shader to be able to take any size chunk. using the 3 dimentions of the workgroups. previously i was only using 1.

also modified the cheeck air function to not take a whole renderer but only the variables it actually needs. this made it alot easier for testing since i didnt need to create a whole renderer (which i cant since i cant create a event_loop in tests)

also created tests for the check air function for the previous smaller size and the actual size i will use as well as larger sizes just to make sure it scales